### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ private
 
 # メソッド名は慣習 deviseにおけるparamsのようなメソッド。新規に追加したカラムをdeviseが受け取れるようにする。
 def configure_permitted_parameters
-# deviseのUserモデルにパラメーターを許可
-  devise_parameter_sanitizer.permit(:sign_up,keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday])
+  # deviseのUserモデルにパラメーターを許可
+  devise_parameter_sanitizer.permit(:sign_up,
+                                    keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday])
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,8 @@ class ItemsController < ApplicationController
 
   def index
     # 記事一覧を新規投稿順に並べる
-    # @items = Item.order("created_at DESC")
+    @items = Item.all.order(id: "DESC")
+   
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,9 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only:[:new]
+  before_action :authenticate_user!, only: [:new]
 
   def index
     # 記事一覧を新規投稿順に並べる
-    @items = Item.all.order(id: "DESC")
-   
+    @items = Item.all.order(id: 'DESC')
   end
 
   def new
@@ -15,16 +14,16 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     if @item.valid?
       @item.save
-      return redirect_to root_path
+      redirect_to root_path
     else
       render :new
     end
   end
 
-
   private
 
   def item_params
-    params.require(:item).permit(:product_name, :text, :price, :category_id, :state_id, :delivery_fee_id, :delivery_prefecture_id, :delivery_date_id, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:product_name, :text, :price, :category_id, :state_id, :delivery_fee_id,
+                                 :delivery_prefecture_id, :delivery_date_id, :image).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -10,7 +10,7 @@ class Category < ActiveHash::Base
     { id: 8, name: '家電・スマホ・カメラ' },
     { id: 9, name: 'スポーツ・レジャー' },
     { id: 10, name: 'ハンドメイド' },
-    { id: 11, name: 'その他' },
+    { id: 11, name: 'その他' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/delivery_date.rb
+++ b/app/models/delivery_date.rb
@@ -3,9 +3,9 @@ class DeliveryDate < ActiveHash::Base
     { id: 1, name: '--' },
     { id: 2, name: '1~2日で発送' },
     { id: 3, name: '2~3日で発送)' },
-    { id: 4, name: '3~7日で発送)' },
+    { id: 4, name: '3~7日で発送)' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
 end

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -2,9 +2,9 @@ class DeliveryFee < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '着払い(購入者負担)' },
-    { id: 3, name: '送料込み(出品者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
 end

--- a/app/models/delivery_prefecture.rb
+++ b/app/models/delivery_prefecture.rb
@@ -47,9 +47,9 @@ class DeliveryPrefecture < ActiveHash::Base
     { id: 45, name: '大分県' },
     { id: 46, name: '宮崎県' },
     { id: 47, name: '鹿児島県' },
-    { id: 48, name: '沖縄県' },
+    { id: 48, name: '沖縄県' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,14 +1,14 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
-  
+
   with_options presence: true do
     validates :product_name
     validates :text, length: { maximum: 1000 }
-    validates :price, numericality:{ only_integer: true, with: /\A[0-9]+\z/, greater_than_or_equal_to:300,
-                                     less_than_or_equal_to:9999999, message:"半角数字300以上9999999以下で入力して下さい" }
+    validates :price, numericality: { only_integer: true, with: /\A[0-9]+\z/, greater_than_or_equal_to: 300,
+                                      less_than_or_equal_to: 9_999_999, message: '半角数字300以上9999999以下で入力して下さい' }
     validates :image
   end
-  #「--」は保存したくないので、ジャンルの選択がid: 1)以外であれば保存できる
+  # 「--」は保存したくないので、ジャンルの選択がid: 1)以外であれば保存できる
   with_options presence: true, numericality: { other_than: 1 } do
     validates :category_id
     validates :state_id
@@ -17,11 +17,10 @@ class Item < ApplicationRecord
     validates :delivery_date_id
   end
 
-
   has_one_attached :image
-  has_one :record 
+  has_one :record
   belongs_to :user
-  
+
   belongs_to_active_hash :category
   belongs_to_active_hash :state
   belongs_to_active_hash :delivery_fee

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -6,7 +6,7 @@ class State < ActiveHash::Base
     { id: 4, name: '目立った傷やよごれなし' },
     { id: 5, name: 'やや傷や汚れあり' },
     { id: 6, name: '傷や汚れあり' },
-    { id: 7, name: '全体的に状態が悪い' },
+    { id: 7, name: '全体的に状態が悪い' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  
+
   with_options presence: true do
     validates :nickname
     validates :birthday
@@ -19,7 +19,7 @@ class User < ApplicationRecord
     validates :last_name_kana
     validates :first_name_kana
   end
-  
+
   has_many :items
   has_many :records
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,12 +125,12 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+       <% if @items.length != 0 %>
+        <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%# <%= link_to "#" do %> 
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,22 +141,20 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.product_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee[:name] %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% end %>
+      <%# 商品がない場合は以下のダミー商品が表示される %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,8 +172,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
+      <%# //商品がない場合は以下のダミー商品が表示される %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -9,12 +9,9 @@ FactoryBot.define do
     delivery_prefecture_id    { 2 }
     delivery_date_id          { 2 }
     association :user
-    
+
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
-    
-    
   end
-  
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Item, type: :model do
       it 'カテゴリーが1だと登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it '商品の状態が空だと登録できない' do
         @item.state_id = ''
@@ -45,7 +45,7 @@ RSpec.describe Item, type: :model do
       it '商品の状態が1だと登録できない' do
         @item.state_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("State must be other than 1")
+        expect(@item.errors.full_messages).to include('State must be other than 1')
       end
       it '配送料が空だと登録できない' do
         @item.delivery_fee_id = ''
@@ -55,7 +55,7 @@ RSpec.describe Item, type: :model do
       it '配送料が1だと登録できない' do
         @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery fee must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery fee must be other than 1')
       end
       it '配送元の地域が空だと登録できない' do
         @item.delivery_prefecture_id = ''
@@ -65,7 +65,7 @@ RSpec.describe Item, type: :model do
       it '配送元の地域が1だと登録できない' do
         @item.delivery_prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery prefecture must be other than 1')
       end
       it '発送までの日数が空だと登録できない' do
         @item.delivery_date_id = ''
@@ -75,7 +75,7 @@ RSpec.describe Item, type: :model do
       it '発送までの日数が1だと登録できない' do
         @item.delivery_date_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery date must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery date must be other than 1')
       end
       it '価格が空だと登録できない' do
         @item.price = ''
@@ -85,17 +85,17 @@ RSpec.describe Item, type: :model do
       it '価格範囲が300未満は登録できない' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price 半角数字300以上9999999以下で入力して下さい")
+        expect(@item.errors.full_messages).to include('Price 半角数字300以上9999999以下で入力して下さい')
       end
       it '価格範囲が9,999,999より大きいと登録できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price 半角数字300以上9999999以下で入力して下さい")
+        expect(@item.errors.full_messages).to include('Price 半角数字300以上9999999以下で入力して下さい')
       end
       it '価格は半角数字でないければ登録できない' do
         @item.price = '１０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price 半角数字300以上9999999以下で入力して下さい")
+        expect(@item.errors.full_messages).to include('Price 半角数字300以上9999999以下で入力して下さい')
       end
     end
   end


### PR DESCRIPTION
# What  
商品一覧機能の実装
# Why
トップページに登録されている商品を全て表示して、ユーザーが購入できるようにするため。

・商品が出品された日時が新しい順に表示できているが画像
https://gyazo.com/8b2b7bcc734b1be4fc20de46ddd9bd5a
・ログアウト状態のユーザーでも、商品一覧表示ページを見ることができる動画
https://gyazo.com/f20b6581637fd08783a2fc43802b0fbb